### PR TITLE
Browser fixture

### DIFF
--- a/login_test.py
+++ b/login_test.py
@@ -14,6 +14,8 @@ dummy_user_firstname = "3141592653" # very unlikely to clash with an existing us
 dummy_user_password = "kbhff2357"
 dummy_user_email = "valid.dummy@email.com"
 
+database_ip = "172.19.0.3"
+
 def create_dummy_user(cursor):
     global dummy_user_firstname, dummy_user_password, dummy_user_email
     #unassigned fields: id, created_at (autoassigned); modified_at, last_login_at (NULLed)
@@ -80,7 +82,8 @@ def get_password_hash_by_userid(user_id, cursor):
 def get_database_connection():
     import mysql.connector as mariadb
 
-    db_connection = mariadb.connect(user='kbhffdk', password='localpass', database='kbhff_dk')
+    global database_ip
+    db_connection = mariadb.connect(user='kbhffdk', password='localpass', database='kbhff_dk', host=database_ip)
     return db_connection
 
 @pytest.fixture

--- a/login_test.py
+++ b/login_test.py
@@ -14,8 +14,6 @@ dummy_user_firstname = "3141592653" # very unlikely to clash with an existing us
 dummy_user_password = "kbhff2357"
 dummy_user_email = "valid.dummy@email.com"
 
-database_ip = "172.19.0.3"
-
 def create_dummy_user(cursor):
     global dummy_user_firstname, dummy_user_password, dummy_user_email
     #unassigned fields: id, created_at (autoassigned); modified_at, last_login_at (NULLed)
@@ -82,8 +80,7 @@ def get_password_hash_by_userid(user_id, cursor):
 def get_database_connection():
     import mysql.connector as mariadb
 
-    global database_ip
-    db_connection = mariadb.connect(user='kbhffdk', password='localpass', database='kbhff_dk', host=database_ip)
+    db_connection = mariadb.connect(user='kbhffdk', password='localpass', database='kbhff_dk', port="54321")
     return db_connection
 
 @pytest.fixture

--- a/login_test.py
+++ b/login_test.py
@@ -116,7 +116,7 @@ def test_cantLoginWithBadCredentials():
             #wait until the error message appears, or 10 seconds, whichever is shorter
             WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//p[@class='error']")))
 
-            assert "forkert brugernavn eller password" in driver.page_source
+            assert "findes ikke" in driver.page_source
 
 
 def test_canLoginWithGoodCredentials(dummy_user):
@@ -131,8 +131,6 @@ def test_canLoginWithGoodCredentials(dummy_user):
 
             password_entry = driver.find_element_by_id("input_password")
             password_entry.send_keys(dummy_user_password)
-            import time
-            time.sleep(3)
             password_entry.submit()
 
             import time

--- a/login_test.py
+++ b/login_test.py
@@ -115,8 +115,9 @@ def try_login(driver, password):
     password_entry = driver.find_element_by_id("input_password")
     password_entry.send_keys(password)
     password_entry.submit()
-
-    WebDriverWait(driver, 10).until(EC.url_changes(login_url))
+    
+    import time
+    time.sleep(0.5) #wait for driver to start loading next page
     # wait for page to load, up to ten seconds
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//html")))
 

--- a/login_test.py
+++ b/login_test.py
@@ -96,50 +96,58 @@ def dummy_user():
 
 
 @pytest.fixture
-def firefox_driver(request, scope = 'function'):
+def driver_list(request, scope = 'function'):
     ''' choosing the driver should be a fixture '''
-    raise NotImplementedError
+    driverlist = [webdriver.Firefox, webdriver.Chrome]
+
+    def driver_generator():
+        for driver_constructor in driverlist:
+            driver = driver_constructor()
+            yield driver
+            driver.quit()
+
+    return driver_generator()
 
 
-def test_cantLoginWithBadCredentials():
+def test_cantLoginWithBadCredentials(driver_list):
     global dummy_user_nickname
-    driver = webdriver.Firefox()
-    driver.get(pages["login"])
+    for driver in driver_list:
+        driver.get(pages["login"])
 
-    username_entry = driver.find_element_by_id("input_username")
-    username_entry.send_keys("dont@email.me")
+        username_entry = driver.find_element_by_id("input_username")
+        username_entry.send_keys("dont@email.me")
 
-    password_entry = driver.find_element_by_id("input_password")
-    password_entry.send_keys("thatsnotmypassword")
-    password_entry.submit()
+        password_entry = driver.find_element_by_id("input_password")
+        password_entry.send_keys("thatsnotmypassword")
+        password_entry.submit()
 
-    #wait until the error message appears, or 10 seconds, whichever is shorter
-    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//p[@class='error']")))
+        #wait until the error message appears, or 10 seconds, whichever is shorter
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//p[@class='error']")))
 
-    assert "forkert brugernavn eller password" in driver.page_source
+        source_to_check = driver.page_source
+        driver.quit()
+        assert "forkert brugernavn eller password" in source_to_check
 
-    driver.quit()
 
-def test_canLoginWithGoodCredentials(dummy_user):
+def test_canLoginWithGoodCredentials(dummy_user, driver_list):
     global dummy_user_nickname
     global dummy_user_password
-    driver = webdriver.Firefox()
-    driver.get(pages["login"])
+    for driver in driver_list:
+        driver.get(pages["login"])
 
-    username_entry = driver.find_element_by_id("input_username")
-    username_entry.send_keys(dummy_user_nickname)
+        username_entry = driver.find_element_by_id("input_username")
+        username_entry.send_keys(dummy_user_nickname)
 
-    password_entry = driver.find_element_by_id("input_password")
-    password_entry.send_keys(dummy_user_password)
-    password_entry.submit()
+        password_entry = driver.find_element_by_id("input_password")
+        password_entry.send_keys(dummy_user_password)
+        password_entry.submit()
 
-    import time
-    time.sleep(3)
-    #wait until redirected to new page, or 10 seconds, whichever is shorter
-    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//html")))
+        import time
+        time.sleep(3)
+        #wait until redirected to new page, or 10 seconds, whichever is shorter
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//html")))
 
-    source_to_check = driver.page_source
-    driver.quit()
-
-    assert "<title>Login</title>" not in source_to_check
+        source_to_check = driver.page_source
+        driver.quit()
+        assert "<title>Login</title>" not in source_to_check
 

--- a/login_test.py
+++ b/login_test.py
@@ -95,59 +95,50 @@ def dummy_user():
     db_connection.commit()
 
 
-@pytest.fixture
-def driver_list(request, scope = 'function'):
-    ''' choosing the driver should be a fixture '''
+def driver_constructor_generator():
     driverlist = [webdriver.Firefox, webdriver.Chrome]
-
-    def driver_generator():
-        for driver_constructor in driverlist:
-            driver = driver_constructor()
-            yield driver
-            driver.quit()
-
-    return driver_generator()
+    yield from driverlist
 
 
-def test_cantLoginWithBadCredentials(driver_list):
+def test_cantLoginWithBadCredentials():
     global dummy_user_nickname
-    for driver in driver_list:
-        driver.get(pages["login"])
+    for driver_constructor in driver_constructor_generator():
+        with driver_constructor() as driver:
+            driver.get(pages["login"])
 
-        username_entry = driver.find_element_by_id("input_username")
-        username_entry.send_keys("dont@email.me")
+            username_entry = driver.find_element_by_id("input_username")
+            username_entry.send_keys("dont@email.me")
 
-        password_entry = driver.find_element_by_id("input_password")
-        password_entry.send_keys("thatsnotmypassword")
-        password_entry.submit()
+            password_entry = driver.find_element_by_id("input_password")
+            password_entry.send_keys("thatsnotmypassword")
+            password_entry.submit()
 
-        #wait until the error message appears, or 10 seconds, whichever is shorter
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//p[@class='error']")))
+            #wait until the error message appears, or 10 seconds, whichever is shorter
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//p[@class='error']")))
 
-        source_to_check = driver.page_source
-        driver.quit()
-        assert "forkert brugernavn eller password" in source_to_check
+            assert "forkert brugernavn eller password" in driver.page_source
 
 
-def test_canLoginWithGoodCredentials(dummy_user, driver_list):
+def test_canLoginWithGoodCredentials(dummy_user):
     global dummy_user_nickname
     global dummy_user_password
-    for driver in driver_list:
-        driver.get(pages["login"])
+    for driver_constructor in driver_constructor_generator():
+        with driver_constructor() as driver:
+            driver.get(pages["login"])
 
-        username_entry = driver.find_element_by_id("input_username")
-        username_entry.send_keys(dummy_user_nickname)
+            username_entry = driver.find_element_by_id("input_username")
+            username_entry.send_keys(dummy_user_nickname)
 
-        password_entry = driver.find_element_by_id("input_password")
-        password_entry.send_keys(dummy_user_password)
-        password_entry.submit()
+            password_entry = driver.find_element_by_id("input_password")
+            password_entry.send_keys(dummy_user_password)
+            import time
+            time.sleep(3)
+            password_entry.submit()
 
-        import time
-        time.sleep(3)
-        #wait until redirected to new page, or 10 seconds, whichever is shorter
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//html")))
+            import time
+            time.sleep(3)
+            #wait until redirected to new page, or 10 seconds, whichever is shorter
+            WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//html")))
 
-        source_to_check = driver.page_source
-        driver.quit()
-        assert "<title>Login</title>" not in source_to_check
+            assert "<title>Login</title>" not in driver.page_source
 


### PR DESCRIPTION
`driver_list` fixtures enables tests to easily work with several browsers by wrapping everything in `for driver in driver_list`. 
This is not ideal, as a failing test in _any_ browser will cause the test for _all_ browsers to fail, see issue #1. 